### PR TITLE
feat: add `--binary-path` to `run-ios` and `run-android` to enable installing pre-build binaries

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -70,7 +70,10 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
       );
     }
 
-    args.binaryPath = path.join(config.root, args.binaryPath);
+    args.binaryPath = path.isAbsolute(args.binaryPath)
+      ? args.binaryPath
+      : path.join(config.root, args.binaryPath);
+
     if (!fs.existsSync(args.binaryPath)) {
       throw new CLIError(
         'binary-path was specified, but the file was not found.',

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -14,6 +14,7 @@ import adb from './adb';
 import runOnAllDevices from './runOnAllDevices';
 import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
+import tryInstallAppOnDevice from './tryInstallAppOnDevice';
 import getAdbPath from './getAdbPath';
 import {
   isPackagerRunning,
@@ -162,64 +163,6 @@ function buildApk(gradlew: string, sourceDir: string) {
   } catch (error) {
     throw new CLIError('Failed to build the app.', error);
   }
-}
-
-function tryInstallAppOnDevice(
-  args: Flags,
-  adbPath: string,
-  device: string,
-  androidProject: AndroidProject,
-) {
-  try {
-    // "app" is usually the default value for Android apps with only 1 app
-    const {appName, sourceDir} = androidProject;
-    const {appFolder} = args;
-    const variant = args.variant.toLowerCase();
-    const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
-    const apkFile = getInstallApkName(
-      appFolder || appName, // TODO: remove appFolder
-      adbPath,
-      variant,
-      device,
-      buildDirectory,
-    );
-
-    const pathToApk = `${buildDirectory}/${apkFile}`;
-    const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
-    logger.info(`Installing the app on the device "${device}"...`);
-    logger.debug(
-      `Running command "cd android && adb -s ${device} install -r -d ${pathToApk}"`,
-    );
-    execa.sync(adbPath, adbArgs, {stdio: 'inherit'});
-  } catch (error) {
-    throw new CLIError('Failed to install the app on the device.', error);
-  }
-}
-
-function getInstallApkName(
-  appName: string,
-  adbPath: string,
-  variant: string,
-  device: string,
-  buildDirectory: string,
-) {
-  const availableCPUs = adb.getAvailableCPUs(adbPath, device);
-
-  // check if there is an apk file like app-armeabi-v7a-debug.apk
-  for (const availableCPU of availableCPUs.concat('universal')) {
-    const apkName = `${appName}-${availableCPU}-${variant}.apk`;
-    if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
-      return apkName;
-    }
-  }
-
-  // check if there is a default file like app-debug.apk
-  const apkName = `${appName}-${variant}.apk`;
-  if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
-    return apkName;
-  }
-
-  throw new CLIError('Could not find the correct install APK file.');
 }
 
 function installAndLaunchOnDevice(

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -55,7 +55,7 @@ export interface Flags {
   binaryPath?: string;
 }
 
-type AndroidProject = NonNullable<Config['project']['android']>;
+export type AndroidProject = NonNullable<Config['project']['android']>;
 
 /**
  * Starts the app on a connected Android emulator or device.
@@ -65,13 +65,17 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
 
   if (args.binaryPath) {
     if (args.tasks) {
-      throw new CLIError('binary-path and tasks were specified, but they are not compatible. Specify only one');
+      throw new CLIError(
+        'binary-path and tasks were specified, but they are not compatible. Specify only one',
+      );
     }
 
-    args.binaryPath = path.join(config.root, args.binaryPath)
+    args.binaryPath = path.join(config.root, args.binaryPath);
     if (!fs.existsSync(args.binaryPath)) {
-      throw new CLIError('binary-path was specified, but the file was not found.');
-    }    
+      throw new CLIError(
+        'binary-path was specified, but the file was not found.',
+      );
+    }
   }
 
   const androidProject = getAndroidProject(config);
@@ -147,8 +151,9 @@ function runOnSpecificDevice(
   const {deviceId} = args;
   if (devices.length > 0 && deviceId) {
     if (devices.indexOf(deviceId) !== -1) {
-      if (!args.binaryPath)
+      if (!args.binaryPath) {
         buildApk(gradlew, androidProject.sourceDir);
+      }
 
       installAndLaunchOnDevice(
         args,
@@ -179,8 +184,6 @@ function buildApk(gradlew: string, sourceDir: string) {
     throw new CLIError('Failed to build the app.', error);
   }
 }
-
-
 
 function installAndLaunchOnDevice(
   args: Flags,
@@ -342,7 +345,8 @@ export default {
     },
     {
       name: '--binary-path <string>',
-      description: 'Path relative to project root where pre-built .apk binary lives.',
+      description:
+        'Path relative to project root where pre-built .apk binary lives.',
     },
   ],
 };

--- a/packages/platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -1,0 +1,68 @@
+import execa from 'execa';
+import fs from 'fs';
+import {
+  logger,
+  CLIError,
+} from '@react-native-community/cli-tools';
+
+import adb from './adb';
+
+function tryInstallAppOnDevice(
+  args: Flags,
+  adbPath: string,
+  device: string,
+  androidProject: AndroidProject,
+) {
+  try {
+    // "app" is usually the default value for Android apps with only 1 app
+    const {appName, sourceDir} = androidProject;
+    const {appFolder} = args;
+    const variant = args.variant.toLowerCase();
+    const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
+    const apkFile = getInstallApkName(
+      appFolder || appName, // TODO: remove appFolder
+      adbPath,
+      variant,
+      device,
+      buildDirectory,
+    );
+
+    const pathToApk = `${buildDirectory}/${apkFile}`;
+    const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
+    logger.info(`Installing the app on the device "${device}"...`);
+    logger.debug(
+      `Running command "cd android && adb -s ${device} install -r -d ${pathToApk}"`,
+    );
+    execa.sync(adbPath, adbArgs, {stdio: 'inherit'});
+  } catch (error) {
+    throw new CLIError('Failed to install the app on the device.', error);
+  }
+}
+
+function getInstallApkName(
+  appName: string,
+  adbPath: string,
+  variant: string,
+  device: string,
+  buildDirectory: string,
+) {
+  const availableCPUs = adb.getAvailableCPUs(adbPath, device);
+
+  // check if there is an apk file like app-armeabi-v7a-debug.apk
+  for (const availableCPU of availableCPUs.concat('universal')) {
+    const apkName = `${appName}-${availableCPU}-${variant}.apk`;
+    if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
+      return apkName;
+    }
+  }
+
+  // check if there is a default file like app-debug.apk
+  const apkName = `${appName}-${variant}.apk`;
+  if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
+    return apkName;
+  }
+
+  throw new CLIError('Could not find the correct install APK file.');
+}
+
+export default tryInstallAppOnDevice;

--- a/packages/platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -18,16 +18,21 @@ function tryInstallAppOnDevice(
     const {appName, sourceDir} = androidProject;
     const {appFolder} = args;
     const variant = args.variant.toLowerCase();
-    const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
-    const apkFile = getInstallApkName(
-      appFolder || appName, // TODO: remove appFolder
-      adbPath,
-      variant,
-      device,
-      buildDirectory,
-    );
 
-    const pathToApk = `${buildDirectory}/${apkFile}`;
+    let pathToApk
+    if (!args.binaryPath) {
+      const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
+      const apkFile = getInstallApkName(
+        appFolder || appName, // TODO: remove appFolder
+        adbPath,
+        variant,
+        device,
+        buildDirectory,
+      );
+      pathToApk = `${buildDirectory}/${apkFile}`;
+    }
+    else pathToApk = args.binaryPath
+
     const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
     logger.info(`Installing the app on the device "${device}"...`);
     logger.debug(

--- a/packages/platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -1,11 +1,9 @@
 import execa from 'execa';
 import fs from 'fs';
-import {
-  logger,
-  CLIError,
-} from '@react-native-community/cli-tools';
+import {logger, CLIError} from '@react-native-community/cli-tools';
 
 import adb from './adb';
+import type {AndroidProject, Flags} from './';
 
 function tryInstallAppOnDevice(
   args: Flags,
@@ -19,7 +17,7 @@ function tryInstallAppOnDevice(
     const {appFolder} = args;
     const variant = args.variant.toLowerCase();
 
-    let pathToApk
+    let pathToApk;
     if (!args.binaryPath) {
       const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
       const apkFile = getInstallApkName(
@@ -30,8 +28,9 @@ function tryInstallAppOnDevice(
         buildDirectory,
       );
       pathToApk = `${buildDirectory}/${apkFile}`;
+    } else {
+      pathToApk = args.binaryPath;
     }
-    else pathToApk = args.binaryPath
 
     const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
     logger.info(`Installing the app on the device "${device}"...`);

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -52,7 +52,10 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   }
 
   if (args.binaryPath) {
-    args.binaryPath = path.join(ctx.root, args.binaryPath);
+    args.binaryPath = path.isAbsolute(args.binaryPath)
+      ? args.binaryPath
+      : path.join(ctx.root, args.binaryPath);
+
     if (!fs.existsSync(args.binaryPath)) {
       throw new CLIError(
         'binary-path was specified, but the file was not found.',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -52,9 +52,11 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   }
 
   if (args.binaryPath) {
-    args.binaryPath = path.join(ctx.root, args.binaryPath)
+    args.binaryPath = path.join(ctx.root, args.binaryPath);
     if (!fs.existsSync(args.binaryPath)) {
-      throw new CLIError('binary-path was specified, but the file was not found.');
+      throw new CLIError(
+        'binary-path was specified, but the file was not found.',
+      );
     }
   }
 
@@ -200,7 +202,7 @@ async function runOnSimulator(
     bootSimulator(selectedSimulator);
   }
 
-  let buildOutput, appPath
+  let buildOutput, appPath;
   if (!args.binaryPath) {
     buildOutput = await buildProject(
       xcodeProject,
@@ -215,9 +217,8 @@ async function runOnSimulator(
       buildOutput,
       scheme,
     );
-  }
-  else {
-    appPath = args.binaryPath
+  } else {
+    appPath = args.binaryPath;
   }
 
   logger.info(`Installing "${chalk.bold(appPath)}"`);
@@ -272,7 +273,7 @@ async function runOnDevice(
     );
   }
 
-  let buildOutput, appPath
+  let buildOutput, appPath;
   if (!args.binaryPath) {
     buildOutput = await buildProject(
       xcodeProject,
@@ -285,11 +286,10 @@ async function runOnDevice(
       xcodeProject,
       args.configuration,
       buildOutput,
-      scheme
+      scheme,
     );
-  }
-  else {
-    appPath = args.binaryPath
+  } else {
+    appPath = args.binaryPath;
   }
 
   const iosDeployInstallArgs = [
@@ -636,7 +636,8 @@ export default {
     },
     {
       name: '--binary-path <string>',
-      description: 'Path relative to project root where pre-built .app binary lives.',
+      description:
+        'Path relative to project root where pre-built .app binary lives.',
     },
     {
       name: '--terminal <string>',


### PR DESCRIPTION
Summary:
---------

Add support for `--binary-path` option to `run-ios` and `run-android`. This allows a caller to specify their own (pre-built) binary that they want to install on devices, while still keeping all the great os/emulator/device support that react-native-community-cli brings.

Test Plan:
----------

setup:
1. clone this repo
2. cd into it and run `yarn link-packages`
3. cd into exodus-mobile and run: `yarn link "@exodus/cli-hermes" "@exodus/cli-server-api" "@react-native-community/cli-types" "@exodus/react-native-community-cli" "@exodus/cli-debugger-ui" "@react-native-community/cli-platform-android" "@react-native-community/cli-platform-ios" "@react-native-community/cli-tools"`

- [x] `react-native run-ios` works & builds from scratch
- [x] `react-native run-ios --device` works & builds from scratch
- [x] `react-native run-ios --binary-path [PATH]` works & installs pre-built `.app` on simulator
- [x] `react-native run-ios --device --binary-path [PATH]` works & installs pre-built `.app` on device
- [x] `react-native run-android` works & builds from scratch
- [x] `react-native run-android --deviceId [ID]` works & builds from scratch
- [x] `react-native run-android --binary-path [PATH]` works & installs pre-built `.apk` on emulator/device
- [x] `react-native run-android --deviceId [ID] --binary-path [PATH]` works & installs pre-built `.apk` on emulator/device
- [x] `react-native run-android --binary-path [PATH] --tasks 'test'` throws; `tasks` and `binary-path` are not compatible